### PR TITLE
Serialize/deserialize keys

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, warn_untyped_record, warnings_as_errors]}.
+
 {cover_enabled, true}.
 {deps, [
         {erlang_pbc, ".*", {git, "https://github.com/helium/erlang_pbc.git", {branch, "master"}}}
@@ -7,3 +8,8 @@
 {plugins, [
            {rebar3_eqc, {git, "https://github.com/Vagabond/rebar3-eqc-plugin", {branch, "master"}}}
     ]}.
+
+{dialyzer, [
+            {warnings, [unknown]},
+            {plt_apps, all_deps}
+           ]}.

--- a/src/tpke_privkey.hrl
+++ b/src/tpke_privkey.hrl
@@ -1,0 +1,11 @@
+-record(privkey, {
+          pubkey :: tpke_pubkey:pubkey(),
+          secret_key :: erlang_pbc:element(),
+          secret_key_index :: non_neg_integer()
+         }).
+
+-record(privkey_serialized, {
+          pubkey :: tpke_pubkey:pubkey_serialized(),
+          secret_key :: binary(),
+          secret_key_index :: non_neg_integer()
+         }).

--- a/src/tpke_pubkey.erl
+++ b/src/tpke_pubkey.erl
@@ -7,7 +7,7 @@
 -type pubkey_serialized() :: #pubkey_serialized{}.
 -type ciphertext() :: {erlang_pbc:element(), binary(), erlang_pbc:element()}.
 
--export_type([pubkey/0, ciphertext/0, curve/0]).
+-export_type([pubkey/0, ciphertext/0, curve/0, pubkey_serialized/0]).
 -export([init/7, lagrange/3, encrypt/2, verify_ciphertext/2, verify_share/3, combine_shares/3, hash_message/2, verify_signature/3, combine_signature_shares/2, verify_signature_share/3, deserialize_element/2, serialize/1, deserialize/1]).
 
 -export([hashH/2]).
@@ -189,10 +189,10 @@ serialize(#pubkey{players=Players, k=K, curve=Curve, g1=G1, g2=G2, verification_
 deserialize(#pubkey_serialized{players=Players, k=K, curve=Curve, g1=G1, g2=G2, verification_key=VK, verification_keys=VKs}) ->
     Group = erlang_pbc:group_new(Curve),
     Element = erlang_pbc:element_new('G1', Group),
-    #pubkey_serialized{players=Players,
-                       k=K,
-                       curve=Curve,
-                       g1=erlang_pbc:binary_to_element(Element, G1),
-                       g2=erlang_pbc:binary_to_element(Element, G2),
-                       verification_key=erlang_pbc:binary_to_element(Element, VK),
-                       verification_keys=[erlang_pbc:binary_to_element(Element, V) || V <- VKs]}.
+    #pubkey{players=Players,
+            k=K,
+            curve=Curve,
+            g1=erlang_pbc:binary_to_element(Element, G1),
+            g2=erlang_pbc:binary_to_element(Element, G2),
+            verification_key=erlang_pbc:binary_to_element(Element, VK),
+            verification_keys=[erlang_pbc:binary_to_element(Element, V) || V <- VKs]}.

--- a/src/tpke_pubkey.erl
+++ b/src/tpke_pubkey.erl
@@ -1,26 +1,21 @@
 -module(tpke_pubkey).
 
--record(pubkey, {
-          players :: pos_integer(),
-          k :: non_neg_integer(),
-          g1 :: erlang_pbc:element(),
-          g2 :: erlang_pbc:element(),
-          verification_key :: erlang_pbc:element(),
-          verification_keys :: [erlang_pbc:element(), ...]
-         }).
+-include("src/tpke_pubkey.hrl").
 
+-type curve() :: 'SS512' | 'MNT159' | 'MNT224'.
 -type pubkey() :: #pubkey{}.
+-type pubkey_serialized() :: #pubkey_serialized{}.
 -type ciphertext() :: {erlang_pbc:element(), binary(), erlang_pbc:element()}.
 
--export_type([pubkey/0, ciphertext/0]).
--export([init/6, lagrange/3, encrypt/2, verify_ciphertext/2, verify_share/3, combine_shares/3, hash_message/2, verify_signature/3, combine_signature_shares/2, verify_signature_share/3, deserialize_element/2]).
+-export_type([pubkey/0, ciphertext/0, curve/0]).
+-export([init/7, lagrange/3, encrypt/2, verify_ciphertext/2, verify_share/3, combine_shares/3, hash_message/2, verify_signature/3, combine_signature_shares/2, verify_signature_share/3, deserialize_element/2, serialize/1, deserialize/1]).
 
 -export([hashH/2]).
 
 %% Note: K can be 0 here, meaning every player is honest.
--spec init(pos_integer(), non_neg_integer(), erlang_pbc:element(), erlang_pbc:element(), erlang_pbc:element(), [erlang_pbc:element(), ...]) -> pubkey().
-init(Players, K, G1, G2, VK, VKs) ->
-    #pubkey{players=Players, k=K, verification_key=VK, verification_keys=VKs, g1=G1, g2=G2}.
+-spec init(pos_integer(), non_neg_integer(), erlang_pbc:element(), erlang_pbc:element(), erlang_pbc:element(), [erlang_pbc:element(), ...], curve()) -> pubkey().
+init(Players, K, G1, G2, VK, VKs, Curve) ->
+    #pubkey{players=Players, k=K, verification_key=VK, verification_keys=VKs, g1=G1, g2=G2, curve=Curve}.
 
 %% Section 3.2.2 Baek and Zheng
 %% Epk(m):

--- a/src/tpke_pubkey.erl
+++ b/src/tpke_pubkey.erl
@@ -174,3 +174,25 @@ xor_bin(<<>>, <<>>, Acc) ->
     list_to_binary(lists:reverse(Acc));
 xor_bin(<<A:8/integer-unsigned, T1/binary>>, <<B:8/integer-unsigned, T2/binary>>, Acc) ->
     xor_bin(T1, T2, [A bxor B | Acc]).
+
+-spec serialize(pubkey()) -> pubkey_serialized().
+serialize(#pubkey{players=Players, k=K, curve=Curve, g1=G1, g2=G2, verification_key=VK, verification_keys=VKs}) ->
+    #pubkey_serialized{players=Players,
+                       k=K,
+                       curve=Curve,
+                       g1=erlang_pbc:element_to_binary(G1),
+                       g2=erlang_pbc:element_to_binary(G2),
+                       verification_key=erlang_pbc:element_to_binary(VK),
+                       verification_keys=[erlang_pbc:element_to_binary(V) || V <- VKs]}.
+
+-spec deserialize(pubkey_serialized()) -> pubkey().
+deserialize(#pubkey_serialized{players=Players, k=K, curve=Curve, g1=G1, g2=G2, verification_key=VK, verification_keys=VKs}) ->
+    Group = erlang_pbc:group_new(Curve),
+    Element = erlang_pbc:element_new('G1', Group),
+    #pubkey_serialized{players=Players,
+                       k=K,
+                       curve=Curve,
+                       g1=erlang_pbc:binary_to_element(Element, G1),
+                       g2=erlang_pbc:binary_to_element(Element, G2),
+                       verification_key=erlang_pbc:binary_to_element(Element, VK),
+                       verification_keys=[erlang_pbc:binary_to_element(Element, V) || V <- VKs]}.

--- a/src/tpke_pubkey.hrl
+++ b/src/tpke_pubkey.hrl
@@ -1,0 +1,19 @@
+-record(pubkey, {
+          players :: pos_integer(),
+          k :: non_neg_integer(),
+          curve :: curve(),
+          g1 :: erlang_pbc:element(),
+          g2 :: erlang_pbc:element(),
+          verification_key :: erlang_pbc:element(),
+          verification_keys :: [erlang_pbc:element(), ...]
+         }).
+
+-record(pubkey_serialized, {
+          players :: pos_integer(),
+          k :: non_neg_integer(),
+          curve :: curve(),
+          g1 :: binary(),
+          g2 :: binary(),
+          verification_key :: binary(),
+          verification_keys :: [binary(), ...]
+         }).

--- a/test/serialize_deserialize_test.erl
+++ b/test/serialize_deserialize_test.erl
@@ -1,0 +1,15 @@
+-module(serialize_deserialize_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("../src/tpke_privkey.hrl").
+
+simple_test() ->
+    dealer:start_link(),
+    {ok, _Group} = dealer:group(),
+    {ok, PubKey, PrivateKeys} = dealer:deal(),
+
+    SerializedPubKey = tpke_pubkey:serialize(PubKey),
+    SerializedPvtKeys = [tpke_privkey:serialize(PK) || PK <- PrivateKeys],
+    Foo = hd(SerializedPvtKeys),
+    ?assertEqual(SerializedPubKey, Foo#privkey_serialized.pubkey),
+    ok.


### PR DESCRIPTION
Add basic support for serializing and deserializing public and private keys. This is kind of required for passing messages with hbbft.