### PR TITLE
Optimize threshold decryption code

### DIFF
--- a/eqc/decrypt_shares_eqc.erl
+++ b/eqc/decrypt_shares_eqc.erl
@@ -29,15 +29,22 @@ prop_decrypt_shares() ->
                               end,
 
                 CipherText = tpke_pubkey:encrypt(PubKey, Message),
+                {ok, VerifiedCipherText} = tpke_pubkey:verify_ciphertext(PubKey, CipherText),
                 FailCipherText = tpke_pubkey:encrypt(FailPubKey, FailMessage),
+                FailVerifiedCipherText = case tpke_pubkey:verify_ciphertext(PubKey, FailCipherText) of
+                                             {ok, _} -> true;
+                                             _ -> false
+                                         end,
 
-                GoodShares = [ tpke_privkey:decrypt_share(SK, CipherText) || SK <- PrivateKeys ],
+                GoodShares = [ tpke_privkey:decrypt_share(SK, VerifiedCipherText) || SK <- PrivateKeys ],
 
                 FailShares = case Fail of
                                  wrong_message ->
-                                     [ tpke_privkey:decrypt_share(SK, FailCipherText) || SK <- FailPKeys ];
+                                     {ok, FCS} = tpke_pubkey:verify_ciphertext(PubKey, FailCipherText),
+                                     [ tpke_privkey:decrypt_share(SK, FCS) || SK <- PrivateKeys ];
                                  _ ->
-                                     [ tpke_privkey:decrypt_share(SK, CipherText) || SK <- FailPKeys ]
+                                     {ok, FCS} = tpke_pubkey:verify_ciphertext(FailPubKey, FailCipherText),
+                                     [ tpke_privkey:decrypt_share(SK, FCS) || SK <- FailPKeys ]
                              end,
 
                 Shares = case Fail of
@@ -51,19 +58,20 @@ prop_decrypt_shares() ->
                                  dealer:random_n(K-1, GoodShares) ++ dealer:random_n(1, FailShares)
                          end,
 
-                VerifiedCipherText = tpke_pubkey:verify_ciphertext(PubKey, CipherText),
-                FailVerifiedCipherText = tpke_pubkey:verify_ciphertext(PubKey, FailCipherText),
-                VerifiedShares = lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(PubKey, Share, CipherText) || Share <- Shares]),
-                VerifiedCombinedShares = tpke_pubkey:combine_shares(PubKey, CipherText, Shares),
+                VerifiedShares = lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(PubKey, Share, VerifiedCipherText) || Share <- Shares]),
+                ValidShares = lists:usort([ Share || Share <- Shares, tpke_pubkey:verify_share(PubKey, Share, VerifiedCipherText) ]),
+                VerifiedCombinedShares = tpke_pubkey:combine_shares(PubKey, VerifiedCipherText, Shares),
 
                 ?WHENFAIL(begin
-                              io:format("Shares ~p~n", [Shares])
+                              io:format("K ~p~n", [K]),
+                              io:format("Shares ~p~n", [Shares]),
+                              io:format("FailShares ~p~n", [FailShares])
                           end,
                           conjunction([
-                                       {verify_ciphertext, VerifiedCipherText},
                                        {dont_verify_wrong_ciphertext, eqc:equals((Fail /= wrong_key), FailVerifiedCipherText)},
                                        {verify_share, eqc:equals((Fail == none orelse Fail == duplicate_shares),  VerifiedShares)},
-                                       {verify_combine_shares, eqc:equals((Fail == none),  Message == VerifiedCombinedShares)}
+                                       {verify_combine_shares, eqc:equals((Fail == none),  Message == VerifiedCombinedShares)},
+                                       {all_shares_validate, eqc:equals((Fail == none), length(Shares) == length(ValidShares))}
                                       ]))
             end).
 

--- a/src/tpke_privkey.erl
+++ b/src/tpke_privkey.erl
@@ -14,7 +14,7 @@
 
 -opaque privkey() :: #privkey{}.
 -opaque privkey_serialized() :: #privkey_serialized{}.
--type share() :: {non_neg_integer(), erlang_pbc:element() | '?'}.
+-type share() :: {non_neg_integer(), erlang_pbc:element()}.
 
 -export_type([privkey/0, share/0, privkey_serialized/0]).
 
@@ -26,18 +26,13 @@ init(PubKey, SecretKey, SecretKeyIndex) ->
 
 %% Section 3.2.2 Baek and Zheng
 %% Dski(C):
--spec decrypt_share(privkey(), {erlang_pbc:element(), binary(), erlang_pbc:element()}) -> share().
-decrypt_share(PrivKey, {U, V, W}) ->
-    Share = case tpke_pubkey:verify_ciphertext(PrivKey#privkey.pubkey, {U, V, W}) of
-                true ->
-                    %% computes Ui = xiU
-                    erlang_pbc:element_mul(PrivKey#privkey.secret_key, U);
-                false ->
-                    '?'
-            end,
+-spec decrypt_share(privkey(), tpke_pubkey:ciphertext()) -> share().
+decrypt_share(PrivKey, CipherText) ->
+    {U, _V, _W} = tpke_pubkey:check_ciphertext(PrivKey#privkey.pubkey, CipherText),
+    %% computes Ui = xiU
+    Share = erlang_pbc:element_mul(PrivKey#privkey.secret_key, U),
     %% output Di = (i, Ui)
     {PrivKey#privkey.secret_key_index, Share}.
-
 
 %% Section 5.2 Boldyrevya
 %% MS

--- a/src/tpke_pubkey.erl
+++ b/src/tpke_pubkey.erl
@@ -20,10 +20,18 @@
           verification_keys :: [binary(), ...]
          }).
 
+-record(ciphertext, {
+        u :: erlang_pbc:element(),
+        v :: <<_:256>>,
+        w :: erlang_pbc:element(),
+        g1 :: erlang_pbc:element() | undefined, %% g1 of the public key this ciphertext is valid with
+        verified = false :: boolean() %% whether we can trust this ciphertext has been verified
+         }).
+
 -type curve() :: 'SS512' | 'MNT159' | 'MNT224'.
 -type pubkey() :: #pubkey{}.
 -type pubkey_serialized() :: #pubkey_serialized{}.
--type ciphertext() :: {erlang_pbc:element(), binary(), erlang_pbc:element()}.
+-opaque ciphertext() :: #ciphertext{}.
 
 -export_type([pubkey/0, ciphertext/0, curve/0, pubkey_serialized/0]).
 -export([init/7,
@@ -40,9 +48,11 @@
          deserialize_element/2,
          verification_key/1,
          serialize/1,
-         deserialize/1]).
-
--export([hashH/2]).
+         deserialize/1,
+         check_ciphertext/2,
+         ciphertext_to_binary/1,
+         binary_to_ciphertext/2
+        ]).
 
 %% Note: K can be 0 here, meaning every player is honest.
 -spec init(pos_integer(), non_neg_integer(), erlang_pbc:element(), erlang_pbc:element(), erlang_pbc:element(), [erlang_pbc:element(), ...], curve()) -> pubkey().
@@ -66,56 +76,50 @@ encrypt(PubKey, Message) when is_binary(Message) ->
     %% W = rH(U, V)
     W = erlang_pbc:element_mul(R, hashH(U, V)),
     %% ciphertext C = (U, V, W)
-    {U, V, W}.
+    #ciphertext{u=U, v=V, w=W}.
 
 %% Section 3.2.2 Baek and Zheng
 %% common code to verify ciphertext is valid
--spec verify_ciphertext(pubkey(), ciphertext()) -> boolean().
-verify_ciphertext(PubKey, {U, V, W}) ->
+-spec verify_ciphertext(pubkey(), ciphertext()) -> {ok, ciphertext()} | error.
+verify_ciphertext(PubKey, #ciphertext{u=U, v=V, w=W}=CipherText) ->
     %% H = H(U, V)
     H = hashH(U, V),
     %% check if ˆe(P, W) = ˆe(U, H)
-    erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g1, W), erlang_pbc:element_pairing(U, H)).
+    case erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g1, W),
+                                erlang_pbc:element_pairing(U, H)) of
+        true ->
+            {ok, CipherText#ciphertext{verified=true, g1=PubKey#pubkey.g1}};
+        false ->
+            error
+    end.
 
 %% Section 3.2.2 Baek and Zheng
 %% Vvk(C, Di):
 -spec verify_share(pubkey(), tpke_privkey:share(), ciphertext()) -> boolean().
-verify_share(PubKey, {Index, Share}, {U, V, W}) ->
+verify_share(PubKey, {Index, Share}, CipherText) ->
+    {U, _V, _W} = check_ciphertext(PubKey, CipherText),
     true = 0 =< Index andalso Index < PubKey#pubkey.players,
-    case verify_ciphertext(PubKey, {U, V, W}) of
-        true when Share == '?' ->
-            false;
-        true ->
-            %% check if ˆe(P, Ui) = ˆe(U, Yi).
-            Yi = lists:nth(Index+1, PubKey#pubkey.verification_keys),
-            erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g2, Share), erlang_pbc:element_pairing(U, Yi));
-        false when Share == '?' ->
-            true;
-        false ->
-            false
-    end.
+    %% check if ˆe(P, Ui) = ˆe(U, Yi).
+    Yi = lists:nth(Index+1, PubKey#pubkey.verification_keys),
+    erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g2, Share),
+                           erlang_pbc:element_pairing(U, Yi)).
 
 %% Section 3.2.2 Baek and Zheng
 %% SCvk(C,{Di}i∈Φ):
 -spec combine_shares(pubkey(), ciphertext(), [tpke_privkey:share(), ...]) -> binary() | undefined.
-combine_shares(PubKey, {U, V, W}, Shares) ->
+combine_shares(PubKey, CipherText, Shares) ->
+    {_U, V, _W} = check_ciphertext(PubKey, CipherText),
     {Indices, _} = lists:unzip(Shares),
     Set = ordsets:from_list(Indices),
     MySet = ordsets:from_list(lists:seq(0, PubKey#pubkey.players - 1)),
     true = ordsets:is_subset(Set, MySet),
 
-    case verify_ciphertext(PubKey, {U, V, W}) of
-        true ->
-            %% m=G(∑i∈ΦλΦ0iUi)⊕V
-            Bleh = [ erlang_pbc:element_pow(Share, lagrange(PubKey, Set, Index)) || {Index, Share} <- Shares, Share /= '?'],
-            Res = lists:foldl(fun(E, Acc) ->
+    %% m=G(∑i∈ΦλΦ0iUi)⊕V
+    Bleh = [ erlang_pbc:element_pow(Share, lagrange(PubKey, Set, Index)) || {Index, Share} <- Shares],
+    Res = lists:foldl(fun(E, Acc) ->
                               erlang_pbc:element_mul(Acc, E)
                       end, hd(Bleh), tl(Bleh)),
-            xor_bin(hashG(Res), V);
-        false ->
-            undefined
-    end.
-
+    xor_bin(hashG(Res), V).
 
 %% Section 3.1 Boldyreva
 %% Decisional Diffie-Hellman (DDH) problem.
@@ -126,7 +130,8 @@ verify_signature_share(PubKey, {Index, Share}, HM) ->
     %% In order to verify the validity of a candidate signature σ of a messageM,
     %% a verifier simply checks whether (g,y,H(M),σ) is a valid Diffie-Hellman tuple.
     %% Given (g,g^x,g^y,g^z) it is possible to check z=xy if e(g,g^z) == e(g^x,g^y)
-    erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g2, Share), erlang_pbc:element_pairing(Y, HM)).
+    erlang_pbc:element_cmp(erlang_pbc:element_pairing(PubKey#pubkey.g2, Share),
+                           erlang_pbc:element_pairing(Y, HM)).
 
 %% Section 3.2 Boldyrevya
 %% V(pk,M,σ) :
@@ -258,3 +263,35 @@ deserialize(#pubkey_serialized{players=Players, k=K, curve=Curve, g1=G1, g2=G2, 
             g2=erlang_pbc:binary_to_element(Element, G2),
             verification_key=erlang_pbc:binary_to_element(Element, VK),
             verification_keys=[erlang_pbc:binary_to_element(Element, V) || V <- VKs]}.
+
+-spec check_ciphertext(pubkey(), ciphertext()) -> {U::erlang_pbc:element(), V::<<_:256>>, W::erlang_pbc:element()}.
+check_ciphertext(_PubKey, #ciphertext{verified=false}) ->
+    erlang:error(unverified_ciphertext);
+check_ciphertext(#pubkey{g1=KG1}, #ciphertext{verified=true, g1=CG1, u=U, v=V, w=W}) ->
+    %% check if they're the same reference or the same value
+    %% reference comparisons are cheaper so do those first
+    case CG1 == KG1 orelse erlang_pbc:element_cmp(CG1, KG1) of
+        true ->
+            {U, V, W};
+        false ->
+            erlang:error(inconsistent_ciphertext)
+    end.
+
+-spec ciphertext_to_binary(ciphertext()) -> binary().
+ciphertext_to_binary(#ciphertext{u=U, v=V, w=W}) ->
+    UBin = erlang_pbc:element_to_binary(U),
+    USize = byte_size(UBin),
+    WBin = erlang_pbc:element_to_binary(W),
+    WSize = byte_size(WBin),
+    <<USize:8/integer-unsigned, UBin:USize/binary, V:32/binary, WSize:8/integer-unsigned, WBin:WSize/binary>>.
+
+-spec binary_to_ciphertext(binary(), tpke_pubkey:pubkey()) -> ciphertext().
+binary_to_ciphertext(<<USize:8/integer-unsigned, UBin:USize/binary, V:32/binary, WSize:8/integer-unsigned, WBin:WSize/binary>>, PubKey) ->
+    U = tpke_pubkey:deserialize_element(PubKey, UBin),
+    W = tpke_pubkey:deserialize_element(PubKey, WBin),
+    case verify_ciphertext(PubKey, #ciphertext{u=U, v=V, w=W}) of
+        {ok, CipherText} ->
+            CipherText;
+        error ->
+            erlang:error(inconsistent_ciphertext)
+    end.

--- a/test/decrypt_SUITE.erl
+++ b/test/decrypt_SUITE.erl
@@ -22,14 +22,29 @@ threshold_decrypt_test(Config) ->
     lists:foreach(fun({ok, Dealer}) ->
                           {ok, _Group} = dealer:group(Dealer),
                           {ok, {PubKey, PrivateKeys}} = dealer:deal(Dealer),
+                          {ok, {OtherPubKey, OtherPrivateKeys}} = dealer:deal(Dealer),
                           {ok, K} = dealer:threshold(Dealer),
                           Message = crypto:hash(sha256, <<"my hovercraft is full of eels">>),
                           CipherText = tpke_pubkey:encrypt(PubKey, Message),
                           %% verify ciphertext
-                          ?assert(tpke_pubkey:verify_ciphertext(PubKey, CipherText)),
-                          Shares = [ tpke_privkey:decrypt_share(SK, CipherText) || SK <- PrivateKeys ],
+                          ?assertError(unverified_ciphertext, [ tpke_privkey:decrypt_share(SK, CipherText) || SK <- PrivateKeys ]),
+                          {ok, VerifiedCipherText} = tpke_pubkey:verify_ciphertext(PubKey, CipherText),
+                          ?assertError(inconsistent_ciphertext, [ tpke_privkey:decrypt_share(SK, VerifiedCipherText) || SK <- OtherPrivateKeys ]),
+                          Shares = [ tpke_privkey:decrypt_share(SK, VerifiedCipherText) || SK <- PrivateKeys ],
                           %% verify share
-                          ?assert(lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(PubKey, Share, CipherText) || Share <- Shares])),
+                          ?assertError(unverified_ciphertext, lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(PubKey, Share, CipherText) || Share <- Shares])),
+                          ?assertError(inconsistent_ciphertext, lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(OtherPubKey, Share, VerifiedCipherText) || Share <- Shares])),
+                          ?assert(lists:all(fun(X) -> X end, [tpke_pubkey:verify_share(PubKey, Share, VerifiedCipherText) || Share <- Shares])),
                           %% verify combine_shares
-                          ?assertEqual(Message, tpke_pubkey:combine_shares(PubKey, CipherText, dealer:random_n(K, Shares)))
+                          ?assertError(unverified_ciphertext, tpke_pubkey:combine_shares(PubKey, CipherText, dealer:random_n(K, Shares))),
+                          ?assertError(inconsistent_ciphertext, tpke_pubkey:combine_shares(OtherPubKey, VerifiedCipherText, dealer:random_n(K, Shares))),
+                          ?assertEqual(Message, tpke_pubkey:combine_shares(PubKey, VerifiedCipherText, dealer:random_n(K, Shares))),
+                          %% test serialization/deserialization
+                          SerializedCipherText = tpke_pubkey:ciphertext_to_binary(VerifiedCipherText),
+                          %% we don't encode validation status
+                          ?assertEqual(SerializedCipherText, tpke_pubkey:ciphertext_to_binary(CipherText)),
+                          DeserializedCipherText = tpke_pubkey:binary_to_ciphertext(SerializedCipherText, PubKey),
+                          ?assertError(inconsistent_ciphertext, tpke_pubkey:binary_to_ciphertext(SerializedCipherText, OtherPubKey)),
+                          ?assertEqual(Message, tpke_pubkey:combine_shares(PubKey, DeserializedCipherText, dealer:random_n(K, Shares))),
+                          ok
                   end, Dealers).


### PR DESCRIPTION
In the Baek and Zhang paper the decrypt_share step can return a valid
share or a `?` to indicate that the ciphertext was not consistent with
the private key. This `?` share was propogated forwards through the
protocol and finally filtered out in the combine_shares step.

These changes reduce the redundant verification done for decryption
shares when generating/validating and combining them. Instead this code
assumes the ciphertext supplied has been explicitly validated with
validate_ciphertext first. This requires more care when using these
functions but can save a significant amount of compute time.